### PR TITLE
Attachment backup implementation

### DIFF
--- a/src/master/util.ts
+++ b/src/master/util.ts
@@ -202,7 +202,9 @@ export async function loadChannel(
                                 avatarURL: msg.avatar,
                                 embeds: msg.embeds,
                                 files: files
-                            }).catch(console.log);
+                            }).catch((err) => {
+                                console.log(err.message);
+                            });
                             if (msg.pinned)
                                 await sentMsg.pin();
                         }

--- a/src/master/util.ts
+++ b/src/master/util.ts
@@ -202,7 +202,7 @@ export async function loadChannel(
                                 avatarURL: msg.avatar,
                                 embeds: msg.embeds,
                                 files: files
-                            });
+                            }).catch(console.log);
                             if (msg.pinned)
                                 await sentMsg.pin();
                         }

--- a/src/master/util.ts
+++ b/src/master/util.ts
@@ -98,6 +98,7 @@ export async function fetchTextChannelData(channel: TextChannel, options: Create
                         avatar: msg.author.displayAvatarURL(),
                         content: msg.cleanContent,
                         embeds: msg.embeds,
+                        attachments: msg.attachments,
                         pinned: msg.pinned
                     });
                 });
@@ -185,14 +186,22 @@ export async function loadChannel(
                     })
                     .then(async webhook => {
                         let messages = (channelData as TextChannelData).messages
-                            .filter(m => m.content.length > 0 || m.embeds.length > 0)
+                            .filter(m => m.content.length > 0 || m.embeds.length > 0 || m.attachments.length > 0)
                             .reverse();
                         messages = messages.slice(messages.length - options.maxMessagesPerChannel);
                         for (const msg of messages) {
+                            let files = [];
+                            if (msg.attachments.length > 0) {
+                                msg.attachments.forEach(attachment => {
+                                    files.push(attachment.url)
+                                });
+                            }
+                            
                             const sentMsg = await webhook.send(msg.content, {
                                 username: msg.username,
                                 avatarURL: msg.avatar,
-                                embeds: msg.embeds
+                                embeds: msg.embeds,
+                                files: files
                             });
                             if (msg.pinned)
                                 await sentMsg.pin();

--- a/src/types/MessageData.ts
+++ b/src/types/MessageData.ts
@@ -1,9 +1,10 @@
-import { MessageEmbed } from "discord.js";
+import { MessageEmbed, MessageAttachment } from "discord.js";
 
 export interface MessageData {
     username: string;
     avatar?: string;
     content?: string;
     embeds?: MessageEmbed[]
+    attachments?: MessageAttachment[];
     pinned?: boolean;
 }

--- a/src/types/MessageData.ts
+++ b/src/types/MessageData.ts
@@ -1,10 +1,10 @@
-import { MessageEmbed, MessageAttachment } from "discord.js";
+import { MessageEmbed, FileOptions } from "discord.js";
 
 export interface MessageData {
     username: string;
     avatar?: string;
     content?: string;
     embeds?: MessageEmbed[]
-    attachments?: MessageAttachment[];
+    files?: FileOptions[];
     pinned?: boolean;
 }


### PR DESCRIPTION
This allows for saving attached images/songs/videos from a message and loading it back as an attachment sent by the webhook.


![Discord_0CHIR6whBV](https://user-images.githubusercontent.com/2727109/85806463-613e6580-b74f-11ea-9438-ab41726f98b3.png)

![Discord_6cWm5b4xCG](https://user-images.githubusercontent.com/2727109/85806548-9ba80280-b74f-11ea-92b2-01203287cb98.png)